### PR TITLE
Fix reference to cover image in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Welcome to the GitHub Copilot Patterns & Exercises documentation! :wave:
 This community-driven opensource guide is dedicated to providing best practices for GitHub Copilot.
 Our aim is to make it straightforward for you to understand, evaluate, and integrate these practices into your projects. :rocket:
 
-<img align="right" src="./assets/cover.png" title="GitHub Copilot Patterns & Exercises" width="40%">
+<img align="right" src="./static/cover.png" title="GitHub Copilot Patterns & Exercises" width="40%">
 
 This document is brought to you by GitHub's Customer Success Architect [@yuhattor](https://github.com/yuhattor/) to help developers better use GitHub Copilot and other AI-Powered tools.
 


### PR DESCRIPTION
The reference to the cover image was broken so this PR fixes that

## Before
![image](https://github.com/yuhattor/copilot-patterns/assets/25424433/98fc3db5-8ff8-49e0-9058-80b4f375b0a7)


## After 
![image](https://github.com/yuhattor/copilot-patterns/assets/25424433/313f8d16-ea00-497d-81dc-9db6d0f666d6)
